### PR TITLE
Specify renderer dependencies - fixes #1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,28 @@
 						</goals>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.freemarker</groupId>
+						<artifactId>freemarker</artifactId>
+						<version>2.3.21</version>
+					</dependency>
+					<dependency>
+						<groupId>org.pegdown</groupId>
+						<artifactId>pegdown</artifactId>
+						<version>1.4.2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.pegdown</groupId>
+						<artifactId>pegdown</artifactId>
+						<version>1.4.2</version>
+					</dependency>	
+					<dependency>
+						<groupId>org.asciidoctor</groupId>
+						<artifactId>asciidoctorj</artifactId>
+						<version>1.5.2</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This specifies the latest dependencies for the plugin, so that sample works after checking out.

It still would be better to handle this in the plugin:
- Either the plugin should include the dependencies and user would need to specify only if another version is needed
- Plugin should resolve and use compile time dependencies so that renderers could be specified as compile-time deps
